### PR TITLE
[caldav] Add sync project in tags

### DIFF
--- a/readme-tw-caldav.md
+++ b/readme-tw-caldav.md
@@ -28,6 +28,7 @@ TW <-> Caldav will make the following mappings between items:
   - `M` <-> 5
   - `H` <-> 1
 - TW `annotations`, `uuid` <-> `DESCRIPTION`
+- TW `project` <-> `CATEGORIES`
 - TW `tags` <-> `CATEGORIES`
 
 ### Current limitations

--- a/syncall/tw_caldav_utils.py
+++ b/syncall/tw_caldav_utils.py
@@ -64,8 +64,19 @@ def convert_tw_to_caldav(tw_item: Item) -> Item:
         caldav_item["start"] = tw_item["due"] - timedelta(hours=1)
         caldav_item["due"] = tw_item["due"]
 
+    # Tags
     if "tags" in tw_item.keys():
         caldav_item["categories"] = tw_item["tags"]
+
+    # Project
+    if "project" in tw_item.keys():
+        # If there are tags use them to prevent overwritting
+        if "tags" in tw_item.keys():
+            project = tw_item["tags"]
+        else:
+            project = []
+        project.append("proj:" + tw_item["project"])
+        caldav_item["categories"] = project
 
     # if start-ed, override the status appropriately
     if "start" in tw_item.keys():
@@ -109,7 +120,15 @@ def convert_caldav_to_tw(caldav_item: Item) -> Item:
         tw_item["due"] = caldav_item["due"]
 
     if "categories" in caldav_item.keys():
-        tw_item["tags"] = caldav_item["categories"]
+        categories = caldav_item["categories"]
+        # Search the first 'proj:tag' and use it for the project
+        # Then remove it from the list
+        for i in categories:
+            if i.startswith("proj:"):
+                tw_item["project"] = i.split(":")[1]
+                categories.remove(i)
+                break
+        tw_item["tags"] = categories
 
     if caldav_item["status"] == "in-process" and "last-modified" in caldav_item:
         tw_item["start"] = caldav_item["last-modified"]


### PR DESCRIPTION
# Description

Add ability to save `project` into caldav tags by prepending with `proj:`, allowing creation of project's specific task directly from caldav.

On Nextcloud Task looks like this:

<img width="393" alt="Screenshot 2023-03-08 at 20 15 48" src="https://user-images.githubusercontent.com/96259932/223818531-f585e625-386e-4cfa-b2d3-ce6b15396ce7.png">


Fixes #73

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Mannually, by creating task from both side and see if they sync correctly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
