### PR TITLE
Fix CalDAV readme referencing nonexisting extra

### DIFF
--- a/readme-tw-caldav.md
+++ b/readme-tw-caldav.md
@@ -41,7 +41,7 @@ Install the `syncall` package from PyPI, enabling the `caldav` and `taskwarrior`
 extra:
 
 ```sh
-pip3 install syncall[caldav, taskwarrior]
+pip3 install 'syncall[caldav, tw]'
 ```
 
 ## Usage


### PR DESCRIPTION
# Description

The CalDAV README file references a non-existing `taskwarrior` installation extra on the example pip command.
This small PR aims to fix that, by referencing the `tw` extra instead.
I've also taken the liberty of adding quoting, as `[]` may be used by bash for other purposes.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tried to follow the README for CalDAV, got the following WARNING from pip:

```
WARNING: syncall 1.5.1 does not provide the extra 'taskwarrior'
```

So I used `tw` instead, and it worked.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
