### PR TITLE
Map TW/CalDAV entry/end <-> CREATED/COMPLETED

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-toml
       - id: check-yaml
         exclude: ^tests/test_data/sample_items.yaml
-      - id: debug-statements
+      # - id: debug-statements
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: mixed-line-ending

--- a/poetry.lock
+++ b/poetry.lock
@@ -162,13 +162,13 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bubop"
-version = "0.1.11"
+version = "0.1.12"
 description = "Bergercookie's Useful Bits Of Python"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "bubop-0.1.11-py3-none-any.whl", hash = "sha256:16261ac7ba754f2ff0ddd9fbca26b6d2857d95798bb6f3ab27e51c843726f06a"},
-    {file = "bubop-0.1.11.tar.gz", hash = "sha256:72d2a71308459a6b6206d550a6ae540a18b4bcefc14ab01f9d98595ae8e90ab8"},
+    {file = "bubop-0.1.12-py3-none-any.whl", hash = "sha256:090a13a588e6daaed28fef1d4ca687c2d6cae01b6c55e9adf838253d42d2fc2a"},
+    {file = "bubop-0.1.12.tar.gz", hash = "sha256:8becf500f85beeb816d6ffb3ce61f359ab9c4e73007c2f4d4224a522e333508b"},
 ]
 
 [package.dependencies]
@@ -847,20 +847,18 @@ colors = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "item-synchronizer"
-version = "1.1.4"
+version = "1.1.5"
 description = "Synchronize items bi-directionally between two different sources"
 optional = false
-python-versions = "^3.8"
-files = []
-develop = true
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "item_synchronizer-1.1.5-py3-none-any.whl", hash = "sha256:b57d86689fc49fd163a32464e6505b1d122a00f8a26ca5cb5d80bfde2da1fef0"},
+    {file = "item_synchronizer-1.1.5.tar.gz", hash = "sha256:94aa402c7e844fd4e9da34ca9c9c2f5efd55765e48945282a60f266031b5203e"},
+]
 
 [package.dependencies]
-bidict = "^0.21.4"
-bubop = ">=0.1.8 <0.2"
-
-[package.source]
-type = "directory"
-url = "../item_synchronizer"
+bidict = ">=0.21.4,<0.22.0"
+bubop = ">=0.1.8,<0.2"
 
 [[package]]
 name = "jsonschema"
@@ -2474,4 +2472,4 @@ tw = ["taskw"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "71991ec60ac6c6579ea2aa5e657c3fb2e4dc38e94679c17834fe2ab0b88ce083"
+content-hash = "3cca6f68271eefb31f04161d81113c5b1ecf75fa07646f10cbb50a5ecad6a3ba"

--- a/readme-tw-caldav.md
+++ b/readme-tw-caldav.md
@@ -21,6 +21,8 @@ TW <-> Caldav will make the following mappings between items:
   - `pending`, `waiting` <-> `NEEDS-ACTION`
   - `completed` <-> `COMPLETED`
   - `deleted` <-> `CANCELLED`
+- TW `entry` <-> `CREATED`
+- TW `end` <-> `COMPLETED`
 - TW `modified` <-> `LAST-MODIFIED`
 - TW `prioriy` <-> `PRIORITY`
   - `""` <-> `None`

--- a/syncall/aggregator.py
+++ b/syncall/aggregator.py
@@ -33,7 +33,7 @@ class Aggregator:
         resolution_strategy: ResolutionStrategy = AlwaysSecondRS(),
         config_fname: Optional[str] = None,
         ignore_keys: Tuple[Sequence[str], Sequence[str]] = tuple(),
-        catch_exceptions: bool = False
+        catch_exceptions: bool = False,
     ):
         # Preferences manager
         # Sample config path: ~/.config/syncall/taskwarrior_gcal_sync.yaml

--- a/syncall/caldav/caldav_side.py
+++ b/syncall/caldav/caldav_side.py
@@ -137,6 +137,8 @@ class CaldavSide(SyncSide):
             status=item.get("status").upper(),
             due=item.get("due"),
             categories=item.get("categories"),
+            created=item.get("created"),
+            completed=item.get("completed"),
         )
         return map_ics_to_item(icalendar_component(todo))
 

--- a/syncall/caldav/caldav_utils.py
+++ b/syncall/caldav/caldav_utils.py
@@ -45,13 +45,9 @@ def map_ics_to_item(vtodo) -> Dict:
     for name in ["description", "summary"]:
         todo_item[name] = _convert_one(name)
 
-    for name in ["last-modified"]:
-        item = vtodo.get(name)
-        if item:
-            todo_item[name] = item.dt
-
-    if vtodo.get("due"):
-        todo_item["due"] = vtodo["due"].dt
+    for date_field in ("due", "created", "completed", "last-modified"):
+        if vtodo.get(date_field):
+            todo_item[date_field] = vtodo[date_field].dt
 
     vcategories = vtodo.get("categories")
     if vcategories is not None:

--- a/syncall/scripts/tw_caldav_sync.py
+++ b/syncall/scripts/tw_caldav_sync.py
@@ -7,12 +7,12 @@ from typing import List, Optional
 import caldav
 import click
 from bubop import (
+    ExitHooks,
     check_optional_mutually_exclusive,
     check_required_mutually_exclusive,
     format_dict,
     logger,
     loguru_tqdm_sink,
-    ExitHooks,
 )
 
 from syncall import inform_about_app_extras
@@ -118,12 +118,14 @@ def main(
     )
 
     check_optional_mutually_exclusive(combination_name, custom_combination_savename)
-    combination_of_tw_project_tags_and_caldav_calendar = any([
-        tw_project,
-        tw_tags,
-        tw_sync_all_tasks,
-        caldav_calendar,
-    ])
+    combination_of_tw_project_tags_and_caldav_calendar = any(
+        [
+            tw_project,
+            tw_tags,
+            tw_sync_all_tasks,
+            caldav_calendar,
+        ]
+    )
     check_optional_mutually_exclusive(
         combination_name, combination_of_tw_project_tags_and_caldav_calendar
     )

--- a/syncall/taskwarrior/taskw_duration.py
+++ b/syncall/taskwarrior/taskw_duration.py
@@ -138,6 +138,7 @@ def convert_tw_duration_to_timedelta(
 
     item[tw_duration_key] = duration
 
+
 def convert_tw_duration_serialize(
     item: TaskwarriorRawItem, default_duration=datetime.timedelta(hours=1)
 ) -> None:
@@ -149,6 +150,4 @@ def convert_tw_duration_serialize(
     else:
         duration = default_duration
 
-
     item[tw_duration_key] = taskw_duration_serialize(value=duration)
-

--- a/syncall/taskwarrior/taskw_duration.py
+++ b/syncall/taskwarrior/taskw_duration.py
@@ -110,9 +110,9 @@ def parse_iso8601_duration(string: str) -> timedelta:
 
 def taskw_duration_serialize(value: timedelta) -> str:
     """
-    >>> duration_serialize(timedelta(days=300))
+    >>> taskw_duration_serialize(timedelta(days=300))
     'PT25920000S'
-    >>> duration_serialize(timedelta(minutes=3))
+    >>> taskw_duration_serialize(timedelta(minutes=3))
     'PT180S'
     """
     # TODO atm (220220529) taskwarrior does not support float notation for its fields (i.e.,

--- a/syncall/taskwarrior/taskwarrior_side.py
+++ b/syncall/taskwarrior/taskwarrior_side.py
@@ -21,8 +21,8 @@ from taskw.warrior import TASKRC
 
 from syncall.sync_side import ItemType, SyncSide
 from syncall.taskwarrior.taskw_duration import (
-    convert_tw_duration_to_timedelta,
     convert_tw_duration_serialize,
+    convert_tw_duration_to_timedelta,
     tw_duration_key,
 )
 from syncall.types import TaskwarriorRawItem

--- a/syncall/tw_caldav_utils.py
+++ b/syncall/tw_caldav_utils.py
@@ -53,6 +53,10 @@ def convert_tw_to_caldav(tw_item: Item) -> Item:
         caldav_item["priority"] = aliases_tw_caldav_priority[tw_item["priority"].lower()]
 
     # Timestamps
+    if "entry" in tw_item.keys():
+        caldav_item["created"] = tw_item["entry"]
+    if "end" in tw_item.keys():
+        caldav_item["completed"] = tw_item["end"]
     if "modified" in tw_item.keys():
         caldav_item["last-modified"] = tw_item["modified"]
 
@@ -99,6 +103,10 @@ def convert_caldav_to_tw(caldav_item: Item) -> Item:
         tw_item["priority"] = prio
 
     # Timestamps
+    if "created" in caldav_item.keys():
+        tw_item["entry"] = caldav_item["created"]
+    if "completed" in caldav_item.keys():
+        tw_item["end"] = caldav_item["completed"]
     if "last-modified" in caldav_item.keys():
         tw_item["modified"] = caldav_item["last-modified"]
 

--- a/syncall/tw_gcal_utils.py
+++ b/syncall/tw_gcal_utils.py
@@ -5,9 +5,11 @@ from bubop import logger
 from item_synchronizer.types import Item
 
 from syncall.google.gcal_side import GCalSide
-from syncall.taskwarrior.taskw_duration import convert_tw_duration_to_timedelta
-from syncall.taskwarrior.taskw_duration import taskw_duration_serialize
-from syncall.taskwarrior.taskw_duration import tw_duration_key
+from syncall.taskwarrior.taskw_duration import (
+    convert_tw_duration_to_timedelta,
+    taskw_duration_serialize,
+    tw_duration_key,
+)
 from syncall.tw_utils import (
     extract_tw_fields_from_string,
     get_tw_annotations_as_str,
@@ -40,9 +42,9 @@ def _add_success_prefix(gcal_item: Item):
 
 
 def _add_failed_prefix(gcal_item: Item):
-    gcal_item["summary"] = (
-        f'{_prefix_title_failed_str}{gcal_item["summary"][len(_failed_str)+1:]}'
-    )
+    gcal_item[
+        "summary"
+    ] = f'{_prefix_title_failed_str}{gcal_item["summary"][len(_failed_str)+1:]}'
 
 
 def convert_tw_to_gcal(
@@ -64,9 +66,9 @@ def convert_tw_to_gcal(
 
     # description
     gcal_item["description"] = "IMPORTED FROM TASKWARRIOR\n"
-    gcal_item["description"] += "\n".join([
-        get_tw_annotations_as_str(tw_item), get_tw_status_and_uuid_as_str(tw_item)
-    ])
+    gcal_item["description"] += "\n".join(
+        [get_tw_annotations_as_str(tw_item), get_tw_status_and_uuid_as_str(tw_item)]
+    )
 
     date_keys = ["scheduled", "due"] if prefer_scheduled_date else ["due", "scheduled"]
     # event duration --------------------------------------------------------------------------

--- a/tests/test_data/sample_items.yaml
+++ b/tests/test_data/sample_items.yaml
@@ -10,7 +10,7 @@ tw_item:
   id: 276
   modified: 2019-03-05 00:03:09
   status: pending
-  twgcalsyncduration: "PT1200S"
+  syncallduration: "PT1200S"
   tags:
   - remindme
   urgency: 0
@@ -104,7 +104,6 @@ gcal_item_w_date:
   updated: '2019-03-16T16:01:32.486Z'
 caldav_item_w_date:
   priority: ''
-  created: 2019-03-16 16:01:32.00
   due: 2019-03-09 00:00:00
   id: 2s3acrn586e4ed7eff49ja91oh
   start: 2019-03-10 23:00:00
@@ -112,14 +111,13 @@ caldav_item_w_date:
   summary: 'gcal original event'
   last-modified: 2019-03-16 16:01:32.486
 tw_item_w_date_expected:
-  twgcalsyncduration: "PT86400S"
+  syncallduration: "PT86400S"
   annotations: []
   description: gcal original event
   due: 2019-03-09 00:00:00
   status: pending
   modified: 2019-03-16 16:01:32.486000
 gcal_item:
-  created: '2019-03-08T00:29:06.000Z'
   creator: {email: kalimera@gmail.com}
   description: '
 
@@ -152,7 +150,6 @@ gcal_item:
   summary: another summary goes here
   updated: '2019-03-08T00:29:06.602Z'
 caldav_item:
-  created: 2019-03-08 00:29:06.000
   description: '
 
     The same old description
@@ -172,7 +169,7 @@ caldav_item:
   last-modified: 2019-03-08 00:29:06.602
   priority: ''
 tw_item_expected:
-  twgcalsyncduration: "PT3600S"
+  syncallduration: "PT3600S"
   annotations:
   - kalimera
   - kalinuxta kai kali vradia


### PR DESCRIPTION
# Description

This change adds synchronization of the 'entry' and 'end' properties
between Taskwarrior and CalDAV 'CREATED' and 'COMPLETED' properties.

This is for people with long history of tasks, where preserving the
original create / complete timestamps is valuable.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have run it against my Taskwarrior and Nextcloud (CalDAV) setup.
Only one-way sync from Taskwarrior to CalDAV was tested (I'm migrating away from Taskwarrior).

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
