### PR TITLE
Add --caldav-passwd-cmd option

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,9 @@ Options:
   --caldav-passwd, --caldav-passwd-pass-path TEXT
                                   Path in the UNIX password manager to fetch
                                   the caldav password from
+  --caldav-passwd-cmd CMD
+                                  A command (which is run in a shell) that
+                                  outputs the caldav password on stdout
   --all, --taskwarrior-all-tasks  Sync all taskwarrior tasks [potentially very
                                   slow]
   -t, --taskwarrior-tags TEXT     Taskwarrior tags to synchronize

--- a/syncall/cli.py
+++ b/syncall/cli.py
@@ -347,3 +347,11 @@ def opt_caldav_passwd_pass_path():
         "caldav_passwd_pass_path",
         help="Path in the UNIX password manager to fetch the caldav password from",
     )
+
+
+def opt_caldav_passwd_cmd():
+    return click.option(
+        "--caldav-passwd-cmd",
+        "caldav_passwd_cmd",
+        help="Command that outputs the caldav password on stdout",
+    )

--- a/syncall/scripts/tw_caldav_sync.py
+++ b/syncall/scripts/tw_caldav_sync.py
@@ -18,8 +18,8 @@ from syncall import inform_about_app_extras
 from syncall.app_utils import error_and_exit
 from syncall.cli import (
     opt_caldav_calendar,
-    opt_caldav_passwd_pass_path,
     opt_caldav_passwd_cmd,
+    opt_caldav_passwd_pass_path,
     opt_caldav_url,
     opt_caldav_user,
     opt_tw_all_tasks,
@@ -200,7 +200,7 @@ def main(
         proc = subprocess.run(caldav_passwd_cmd, shell=True, text=True, capture_output=True)
         if proc.returncode != 0:
             error_and_exit(f"Password command failed: {proc.stderr}")
-        # Remove trailing newline/whitespace
+
         caldav_passwd = proc.stdout.rstrip()
     else:
         caldav_passwd = fetch_from_pass_manager(caldav_passwd_pass_path)

--- a/syncall/scripts/tw_caldav_sync.py
+++ b/syncall/scripts/tw_caldav_sync.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import subprocess
 from typing import List, Optional
 
 import caldav
@@ -18,6 +19,7 @@ from syncall.app_utils import error_and_exit
 from syncall.cli import (
     opt_caldav_calendar,
     opt_caldav_passwd_pass_path,
+    opt_caldav_passwd_cmd,
     opt_caldav_url,
     opt_caldav_user,
     opt_tw_all_tasks,
@@ -56,6 +58,7 @@ from syncall import (
 @opt_caldav_url()
 @opt_caldav_user()
 @opt_caldav_passwd_pass_path()
+@opt_caldav_passwd_cmd()
 # taskwarrior options -------------------------------------------------------------------------
 @opt_tw_all_tasks()
 @opt_tw_tags()
@@ -73,6 +76,7 @@ def main(
     caldav_url: str,
     caldav_user: Optional[str],
     caldav_passwd_pass_path: str,
+    caldav_passwd_cmd: str,
     tw_sync_all_tasks: bool,
     tw_tags: List[str],
     tw_project: str,
@@ -192,6 +196,12 @@ def main(
     caldav_passwd = os.environ.get("CALDAV_PASSWD")
     if caldav_passwd is not None:
         logger.debug("Reading the caldav password from environment variable...")
+    elif caldav_passwd_cmd is not None:
+        proc = subprocess.run(caldav_passwd_cmd, shell=True, text=True, capture_output=True)
+        if proc.returncode != 0:
+            error_and_exit(f"Password command failed: {proc.stderr}")
+        # Remove trailing newline/whitespace
+        caldav_passwd = proc.stdout.rstrip()
     else:
         caldav_passwd = fetch_from_pass_manager(caldav_passwd_pass_path)
 


### PR DESCRIPTION
# Description

I don't use password-store and don't like having my passwords in process
listings (which easily happens if using the $CALDAV_PASSWD env var).

This patch offers an alternative, by specifying a command-line that
outputs the password on stdout, for example:

  --caldav-passwd-cmd="cat /run/secrets/caldav-pw"

The command is run through a shell, so "cat ~/mypassword" also works.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

My test command-line:

  pip3 install --upgrade .[gkeep,fs,google,tw,caldav,asana] && tw_caldav_sync --caldav-passwd-cmd="cat ~/caldav.pw" --caldav-calendar "syncall-test-6" --caldav-url https://example.com/nextcloud/remote.php/dav/files/myuser/ --caldav-user myuser --all

Without the --caldav-passwd-cmd, it uses password-store like before.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
