### PR TITLE
readme-tw-caldav.md: clarify status property mapping

### DIFF
--- a/readme-tw-caldav.md
+++ b/readme-tw-caldav.md
@@ -18,9 +18,9 @@ TW <-> Caldav will make the following mappings between items:
 
 - `description` <-> `SUMMARY`
 - `status` <-> `STATUS`
-  - `pending`, `waiting` <-> `NEEDS-ACTION`
-  - `completed` <-> `COMPLETED`
-  - `deleted` <-> `CANCELLED`
+  - `pending`, `waiting` <-> `STATUS:NEEDS-ACTION`
+  - `completed` <-> `STATUS:COMPLETED`
+  - `deleted` <-> `STATUS:CANCELLED`
 - TW `modified` <-> `LAST-MODIFIED`
 - TW `prioriy` <-> `PRIORITY`
   - `""` <-> `None`


### PR DESCRIPTION
# Description

CalDAV objects have a `COMPLETED` property, but what is discussed here is the `STATUS` property, with the value `COMPLETED`, so let's update the doc and be precise by prefixing the values with `STATUS:`.

## Type of change

[x] Small documentation update.

# How Has This Been Tested?

No testing, just edited a few lines in a readme.
