### PR TITLE
pyproject: use poetry-core instead of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,7 @@ addopts = ["--ignore-glob=quickstart*", "--doctest-modules"]
 
 # build-system -----------------------------------------------------------------
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 # vim: tw=80


### PR DESCRIPTION
# Description

The PEP517 backend for poetry has been extracted in a separate package as per https://pypi.org/project/poetry-core/

Fixes the ability to package this for NixOS, a Linux distribution.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I just built the project with poetry-core.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
