### PR TITLE
New CalDAV description format

### DIFF
--- a/docs/readme-tw-caldav.md
+++ b/docs/readme-tw-caldav.md
@@ -29,7 +29,8 @@ TW <-> Caldav will make the following mappings between items:
   - `L` <-> 9
   - `M` <-> 5
   - `H` <-> 1
-- TW `annotations`, `uuid` <-> `DESCRIPTION`
+- TW `annotations` <-> `DESCRIPTION` (one annotation <-> one line in description)
+- TW `uuid` <-> `X-SYNCALL-TW-UUID`
 - TW `tags` <-> `CATEGORIES`
 
 ### Current limitations

--- a/syncall/caldav/caldav_side.py
+++ b/syncall/caldav/caldav_side.py
@@ -27,6 +27,7 @@ class CaldavSide(SyncSide):
         "status",
         "summary",
         "due",
+        "x-syncall-tw-uuid",
     )
 
     _date_keys: tuple[str] = ("end", "start", "last-modified")
@@ -144,6 +145,7 @@ class CaldavSide(SyncSide):
             categories=item.get("categories"),
             created=item.get("created"),
             completed=item.get("completed"),
+            x_syncall_tw_uuid=item.get("x-syncall-tw-uuid"),
         )
         return map_ics_to_item(icalendar_component(todo))
 

--- a/syncall/caldav/caldav_utils.py
+++ b/syncall/caldav/caldav_utils.py
@@ -46,6 +46,7 @@ def map_ics_to_item(vtodo) -> dict:
         todo_item[name] = _convert_one(name).lower()
     for name in ["description", "summary"]:
         todo_item[name] = _convert_one(name)
+    todo_item["uuid"] = _convert_one("x-syncall-tw-uuid")
 
     for date_field in ("due", "created", "completed", "last-modified"):
         if vtodo.get(date_field):

--- a/tests/test_data/sample_items.yaml
+++ b/tests/test_data/sample_items.yaml
@@ -35,35 +35,25 @@ tw_item_w_due:
   - This is the annotation text
   - This is the other annotation text
 caldav_item_expected:
-  description: 'IMPORTED FROM TASKWARRIOR
-
-
-    * Annotation 1: This is the annotation text
-
-    * Annotation 2: This is the other annotation text
-
-
-    * uuid: 00208973-20da-4988-ae3e-58ef3650c363'
+  description: |-
+    This is the annotation text
+    This is the other annotation text
   summary: Kalimera!
   last-modified: 2019-03-05 00:03:09
   status: 'needs-action'
   categories: ['remindme']
+  x-syncall-tw-uuid: '00208973-20da-4988-ae3e-58ef3650c363'
 caldav_item_w_date_expected:
-  description: 'IMPORTED FROM TASKWARRIOR
-
-
-    * Annotation 1: This is the annotation text
-
-    * Annotation 2: This is the other annotation text
-
-
-    * uuid: 00208973-20da-4988-ae3e-58ef3650c363'
+  description: |-
+    This is the annotation text
+    This is the other annotation text
   due: 2019-03-09 00:00:00
   start: 2019-03-08 23:00:00
   summary: Kalimera!
   last-modified: 2019-03-05 00:03:09
   status: 'needs-action'
   categories: ['remindme']
+  x-syncall-tw-uuid: '00208973-20da-4988-ae3e-58ef3650c363'
 gcal_item_expected:
   description: 'IMPORTED FROM TASKWARRIOR
 
@@ -150,17 +140,9 @@ gcal_item:
   summary: another summary goes here
   updated: '2019-03-08T00:29:06.602Z'
 caldav_item:
-  description: '
-
-    The same old description
-
-
-    * Annotation 1: kalimera
-
-    * Annotation 2: kalinuxta kai kali vradia
-
-
-    * uuid: 00208973-20da-4988-ae3e-58ef3650c363'
+  description: |-
+    kalimera
+    kalinuxta kai kali vradia
   due: 2019-03-04 05:00:00
   id: 52ggba92l9ph4d0ghabi3ohdh7
   start: 2019-03-04 04:00:00
@@ -168,6 +150,7 @@ caldav_item:
   summary: another summary goes here
   last-modified: 2019-03-08 00:29:06.602
   priority: ''
+  x-syncall-tw-uuid: '00208973-20da-4988-ae3e-58ef3650c363'
 tw_item_expected:
   syncallduration: "PT3600S"
   annotations:


### PR DESCRIPTION
# Description

## TL;DR

Old mappings:
- TW `annotations`, `uuid` <-> `DESCRIPTION`

New mappings:
- TW `uuid` <-> `X-SYNCALL-TW-UUID`
- TW `annotations` <-> `DESCRIPTION` (each annotation <-> a line in description)

## Old mappings

If I understand the code correctly, the previous implementation uses the field `DESCRIPTION` of caldav to store meta-data of TW items.

When a TW item is converted to caldav item, the `annotations` and `uuid` of TW item are encoded into the following format, and stored in `DESCRIPTION` of caldav.
```plaintext
IMPORTED FROM TASKWARRIOR

* Annotation 1: first annotation
* Annotation 2: second annotation
* Annotation 3: third annotation
* uuid: 12345678-123-1234-1234-1234567890ab
```

When a caldav item is converted to TW item, syncall will try to parse the `DESCRIPTION` field of caldav item from the above format to get back the `annotation` and `uuid`. If lines not starting with `* Annotation` or `* uuid` will be ignored.

## Problems of the old mappings

It makes the `DESCRIPTION` field of caldav unusable.

When user creates a task with description on caldav side, the description will be ignored by syncall and never reached taskwarrior. (Related issue: #72)

Some caldav application like Apple Reminder shows the description right below the task summary. The meta-data in `DESCRIPTION` takes up a lot of screen space, and make the task list bloat.

![IMG_3826](https://github.com/bergercookie/syncall/assets/11942650/b7169f53-af90-4682-b7d2-e90f173d7207)

## New mappings

In this new mappings, the `uuid` of TW item will be mapped to a non-standard iCalendar field `X-SYNCALL-TW-UUID`, allowed by RFC 5545. The `annotation` of TW item will be mapped to `DESCRIPTION` of caldav item. Each line in `DESCRIPTION` is corresponding to an annotation.

## Remark

- To avoid messing up the existing items with old mapping, syncall will try to parse the description as old mapping does, but any new synchronization will use the new mapping.
- Lines in `DESCRIPTION` in caldav may be re-ordered after modifying the text and synchonizing. It is because the annotations in TW are sorted by the modified timestamp.
- This patch works fine for my simple daily use, but I didn't test many edge cases.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Updated the test samples in `test/test_data/sample_items.yaml`, and ran the tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

Edit: forgot to embed the screenshot