### PR TITLE
Fix/tw priority bug

### DIFF
--- a/syncall/tw_caldav_utils.py
+++ b/syncall/tw_caldav_utils.py
@@ -92,7 +92,7 @@ def convert_tw_to_caldav(tw_item: Item) -> Item:
     if "priority" in tw_item.keys() and tw_item["priority"].lower() in aliases_tw_caldav_priority.keys():
         caldav_item["priority"] = aliases_tw_caldav_priority[tw_item["priority"].lower()]
     else:
-        caldav_item["priority"] = 0
+        caldav_item["priority"] = ""
 
     # Timestamps
     if "entry" in tw_item:

--- a/syncall/tw_caldav_utils.py
+++ b/syncall/tw_caldav_utils.py
@@ -88,11 +88,11 @@ def convert_tw_to_caldav(tw_item: Item) -> Item:
         tw_item=tw_item,
     )
 
-    # Priority
-    if "priority" in tw_item:
+    # Priority - tw treats priority as a UDA, so any custom options just ignore for now
+    if "priority" in tw_item.keys() and tw_item["priority"].lower() in aliases_tw_caldav_priority.keys():
         caldav_item["priority"] = aliases_tw_caldav_priority[tw_item["priority"].lower()]
     else:
-        caldav_item["priority"] = ""
+        caldav_item["priority"] = 0
 
     # Timestamps
     if "entry" in tw_item:

--- a/syncall/tw_caldav_utils.py
+++ b/syncall/tw_caldav_utils.py
@@ -89,7 +89,11 @@ def convert_tw_to_caldav(tw_item: Item) -> Item:
     )
 
     # Priority - tw treats priority as a UDA, so any custom options just ignore for now
-    if "priority" in tw_item.keys() and tw_item["priority"].lower() in aliases_tw_caldav_priority.keys():
+    if (
+        "priority" in tw_item.keys()
+        and tw_item["priority"].lower() in aliases_tw_caldav_priority.keys()
+    ):
+
         caldav_item["priority"] = aliases_tw_caldav_priority[tw_item["priority"].lower()]
     else:
         caldav_item["priority"] = ""

--- a/tests/test_tw_caldav_conversions.py
+++ b/tests/test_tw_caldav_conversions.py
@@ -2,7 +2,6 @@ import datetime
 
 import pytest
 from dateutil.tz import tzutc
-
 from syncall.caldav.caldav_side import CaldavSide
 from syncall.taskwarrior.taskwarrior_side import TaskWarriorSide
 from syncall.tw_caldav_utils import (

--- a/tests/test_tw_caldav_conversions.py
+++ b/tests/test_tw_caldav_conversions.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 from dateutil.tz import tzutc
+
 from syncall.caldav.caldav_side import CaldavSide
 from syncall.taskwarrior.taskwarrior_side import TaskWarriorSide
 from syncall.tw_caldav_utils import (
@@ -156,7 +157,7 @@ def caldav_item_with_priority(prio: int) -> dict:
                 tw_pending_item_with_priority(tw_prio),
                 caldav_item_with_priority(caldav_prio),
             )
-            for tw_prio, caldav_prio in [("L", 9), ("M", 5), ("H", 1)]
+            for tw_prio, caldav_prio in [("L", 9), ("M", 5), ("H", 1), ("T", 0)]
         ),
     ],
     ids=[
@@ -169,6 +170,7 @@ def caldav_item_with_priority(prio: int) -> dict:
         "pending_item_with_priority_L",
         "pending_item_with_priority_M",
         "pending_item_with_priority_H",
+        "pending_item_with_priority_T",
     ],
 )
 def test_convert_tw_to_caldav_n_back(tw_item, caldav_item_expected):


### PR DESCRIPTION
# Description

Hi!

First of all syncall is still awesome, I genuinely couldn't work without it as part of my daily flow.
Also apologies for not really being involved since I threw the `caldav` PR at you some time ago!

This is a bug I've noticed when using caldav syncall for a while now, but haven't got around to fixing.
Basically tw treats `priority` as a UDA, so can technically be anything, while the `caldav` side expects it to be either L/M/H (the defaults), otherwise it throws an error.

As fully supporting UDAs is a massive faff, I've added a simple check that if `priority` is present in the TW side, if it is not in L/M/H, then it will just be set to 0 on the caldav side. Have also included a test case for the new behaviour.

Let me know if this needs any further info/testing, and thanks once again!

Fixes # (issue)

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Added pytest case for additional behaviour case
- [x] Have tested on my own home config, and do not get errors anymore

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
