### PR TITLE
[tw-caldav] Fix no priority RFC complaince

### DIFF
--- a/syncall/caldav/caldav_side.py
+++ b/syncall/caldav/caldav_side.py
@@ -29,6 +29,7 @@ class CaldavSide(SyncSide):
         "status",
         "summary",
         "due",
+        "priority",
         SYNCALL_TW_WAITING,
     )
 

--- a/syncall/tw_caldav_utils.py
+++ b/syncall/tw_caldav_utils.py
@@ -92,7 +92,7 @@ def convert_tw_to_caldav(tw_item: Item) -> Item:
     if "priority" in tw_item:
         caldav_item["priority"] = aliases_tw_caldav_priority[tw_item["priority"].lower()]
     else:
-        caldav_item["priority"] = ""
+        caldav_item["priority"] = 0
 
     # Timestamps
     if "entry" in tw_item:

--- a/tests/test_tw_caldav_conversions.py
+++ b/tests/test_tw_caldav_conversions.py
@@ -26,7 +26,7 @@ tw_pending_item = {
 caldav_pending_item = {
     "summary": "task in project - and with date",
     "description": "",
-    "priority": "",
+    "priority": 0,
     SYNCALL_TW_UUID: "4471f2ac-4a70-4012-9eff-b4ddfc860d26",
     "status": "needs-action",
     SYNCALL_TW_WAITING: "false",


### PR DESCRIPTION
# Description

According to the RFC, the correct value for an undefined priority is 0, not an empty string. The `caldav` package definitely chokes on non-int priorities making it to server-side, when trying to download them.

Link: https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.9

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration

- I checked in `nextcloud` and the Tasks android app that indeed "no priority" is priority=0, so at least these two applications take the RFC seriously
- I enable checking priority for caldav items, so now the test will fail if the priority is not 0 or one of the mapped numbers

## Checklist

N/A is striked through

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] Any dependent changes have been merged and published in downstream modules~~
