### PR TITLE
chore: Bump Poetry and Python versions and drop EoL versions of Python

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Python Poetry Action
         uses: abatilo/actions-poetry@v2.1.3
         with:
-          poetry-version: "1.6.1"
+          poetry-version: "2.4.1"
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "poetry"
       - name: Install prerequisites
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
           poetry-version: "1.6.1"
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "poetry"
       - name: Install prerequisites
         run: |

--- a/.github/workflows/install-software.yml
+++ b/.github/workflows/install-software.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -26,7 +26,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         # use python-extra AND executable to tests its imports
         # https://stackoverflow.com/questions/66025220/paired-values-in-github-actions-matrix
         python-extra:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ jobs:
           poetry-version: "1.6.1"
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
           cache: "poetry"
       - name: Install prerequisites
         run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Python Poetry Action
         uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.6.1"
+          poetry-version: "2.4.1"
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "poetry"
       - name: Install prerequisites
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Python Poetry Action

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Python Poetry Action
         uses: abatilo/actions-poetry@v2.1.3
         with:
-          poetry-version: "1.6.1"
+          poetry-version: "2.4.1"
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ python-dateutil = "^2.9.0.post0"
 rfc3339 = "^6.2"
 item-synchronizer = "^1.1.5"
 bubop = { version = "0.1.12", allow-prereleases = true }
-setuptools = { version = "^72.1.0", optional = true, python = ">=3.12" }
+setuptools = { version = "<82", optional = true, python = ">=3.12" }
 
 [tool.poetry.extras]
 google = ["google-api-python-client", "google-auth-oauthlib", "setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ tw_gtasks_sync = "syncall.scripts.tw_gtasks_sync:main"
 
 # end-user dependencies --------------------------------------------------------
 [tool.poetry.dependencies]
-python = ">=3.8.1,<=3.12.5"
+python = ">=3.10"
 
 PyYAML = "~5.3.1"
 bidict = "^0.21.4"


### PR DESCRIPTION
# Description

This PR bumps Poetry and Python versions in CI and drops EoL versions of Python from CI and the project.

Python 3.8 and 3.9 are EoL, and 3.10 and 3.11 are nearing EoL in October 2026.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration

- [ ] Test A
- [ ] Test B

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
